### PR TITLE
Change how spline coefficients are returned to spline epistasis models

### DIFF
--- a/epistasis/models/nonlinear/spline.py
+++ b/epistasis/models/nonlinear/spline.py
@@ -88,9 +88,11 @@ class SplineMinizer(Minimizer):
             k=self.k,
             s=self.s
         )
-
         for i, coef in enumerate(self._spline.get_coeffs()):
-            self.parameters['c{}'.format(i)].value = coef
+            if 'c{}'.format(i) in self.parameters:
+                self.parameters['c{}'.format(i)].value = coef
+            else:
+                self.parameters.add(name='c{}'.format(i), value=coef)
 
 # -------------------- Minimizer object ------------------------
 

--- a/epistasis/models/nonlinear/spline.py
+++ b/epistasis/models/nonlinear/spline.py
@@ -90,22 +90,15 @@ class SplineMinizer(Minimizer):
             s=self.s
         )
         
-        keys = []
-        warned = False
         for i, coef in enumerate(self._spline.get_coeffs()):
             if 'c{}'.format(i) in self.parameters:
                 self.parameters['c{}'.format(i)].value = coef
             else:
-                if not warned:
-                    warnings.warn('Spline fitting added knots, try raising "s"', Warning)
-                    warned = True
-                self.parameters.add(name='c{}'.format(i), value=coef)
-            keys.append('c{}'.format(i))
-        for key in self.parameters:
-            if key not in keys: 
-                raise ValueError(
-                    'Parameter {} not returned after fitting'.format(key)
-                    )
+                raise FittingError('scipy.interpolate.UnivariateSpline '
+                'fitting returned more parameters than\nexpected, likely'
+                ' due to knots being added to closer fit the data.\nTry '
+                'raising the size of `s` when initializing the spline '
+                'model to prevent this.')
 # -------------------- Minimizer object ------------------------
 
 class EpistasisSpline(EpistasisNonlinearRegression):

--- a/epistasis/models/nonlinear/spline.py
+++ b/epistasis/models/nonlinear/spline.py
@@ -88,12 +88,19 @@ class SplineMinizer(Minimizer):
             k=self.k,
             s=self.s
         )
+        
+        keys = []
         for i, coef in enumerate(self._spline.get_coeffs()):
             if 'c{}'.format(i) in self.parameters:
                 self.parameters['c{}'.format(i)].value = coef
             else:
                 self.parameters.add(name='c{}'.format(i), value=coef)
-
+            keys.append('c{}'.format(i))
+        for key in self.parameters:
+            if key not in keys: 
+                raise ValueError(
+                    f"Parameter {key} not returned after fitting"
+                    )
 # -------------------- Minimizer object ------------------------
 
 class EpistasisSpline(EpistasisNonlinearRegression):

--- a/epistasis/models/nonlinear/spline.py
+++ b/epistasis/models/nonlinear/spline.py
@@ -99,7 +99,7 @@ class SplineMinizer(Minimizer):
         for key in self.parameters:
             if key not in keys: 
                 raise ValueError(
-                    f"Parameter {key} not returned after fitting"
+                    'Parameter {} not returned after fitting'.format(key)
                     )
 # -------------------- Minimizer object ------------------------
 

--- a/epistasis/models/nonlinear/spline.py
+++ b/epistasis/models/nonlinear/spline.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from .minimizer import Minimizer
 from .ordinary import EpistasisNonlinearRegression
@@ -90,10 +91,14 @@ class SplineMinizer(Minimizer):
         )
         
         keys = []
+        warned = False
         for i, coef in enumerate(self._spline.get_coeffs()):
             if 'c{}'.format(i) in self.parameters:
                 self.parameters['c{}'.format(i)].value = coef
             else:
+                if not warned:
+                    warnings.warn('Spline fitting added knots, try raising "s"', Warning)
+                    warned = True
                 self.parameters.add(name='c{}'.format(i), value=coef)
             keys.append('c{}'.format(i))
         for key in self.parameters:

--- a/epistasis/models/nonlinear/spline.py
+++ b/epistasis/models/nonlinear/spline.py
@@ -1,5 +1,4 @@
 import numpy as np
-import warnings
 
 from .minimizer import Minimizer
 from .ordinary import EpistasisNonlinearRegression
@@ -97,7 +96,7 @@ class SplineMinizer(Minimizer):
                 raise FittingError('scipy.interpolate.UnivariateSpline '
                 'fitting returned more parameters than\nexpected, likely'
                 ' due to knots being added to closer fit the data.\nTry '
-                'raising the size of `s` when initializing the spline '
+                'raising the value of `s` when initializing the spline '
                 'model to prevent this.')
 # -------------------- Minimizer object ------------------------
 


### PR DESCRIPTION
The spline fitting method in the epistasis package uses UnivariateSpline from scipy. After using this method to fit a spline to the data, spline coefficients are returned to the epistasis spline model. However, the number of coefficients in the spline model is initialized based on a user input, and a dictionary is made with a key for each of those coefficients. UnivariateSpline tries to 'smooth' the curve it fits to the data based on a 'smoothness' input, 's', regardless of how many 'k' coefficients you tell it to use. This results in it adding more spline coefficients, and when the code tries to return the coefficients to the dictionary, a key error occurs because those coefficients were not in the dictionary before. Previously, the spline fit only seemed to work when there's not much noise in the data, because UnivariateSpline doesn't have to add more coefficients in those cases to achieve the default level of 'smoothness'. I have modified how the coefficients are returned to the epistasis spline model so that more coefficients can be added to the dictionary, and the spline fit now works with data with more levels of noise. I also made it check that the number of coefficients is not reduced, since I believe this should not be a possible outcome of the fitting. 