### PR TITLE
Use encoding table in GPMap to build coeffs.

### DIFF
--- a/epistasis/__version__.py
+++ b/epistasis/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 6, 8)
+VERSION = (0, 7, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/epistasis/models/ensemble.py
+++ b/epistasis/models/ensemble.py
@@ -6,7 +6,7 @@ from sklearn.base import BaseEstimator, RegressorMixin
 
 
 from epistasis.stats import pearson
-from ..mapping import EpistasisMap, mutations_to_sites
+from ..mapping import EpistasisMap, encoding_to_sites
 from .base import BaseModel
 from epistasis.matrix import get_model_matrix
 from .utils import arghandler

--- a/epistasis/models/utils.py
+++ b/epistasis/models/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 from functools import wraps
 from epistasis.matrix import get_model_matrix
-from epistasis.mapping import EpistasisMap, mutations_to_sites
+from epistasis.mapping import EpistasisMap
 
 from gpmap.utils import genotypes_to_binary
 

--- a/epistasis/pyplot/coefs.py
+++ b/epistasis/pyplot/coefs.py
@@ -97,8 +97,8 @@ def plot_coefs(model=None, sites=None, values=None, errors=None, **kwargs):
     """
     # Some sanity checks.
     if model is not None:
-        sites = model.epistasis.sites
-        values = model.epistasis.values
+        sites = model.epistasis.sites[1:]
+        values = model.epistasis.values[1:]
 
     else:
         if sites is None:

--- a/epistasis/simulate/base.py
+++ b/epistasis/simulate/base.py
@@ -3,7 +3,7 @@ from gpmap.gpm import GenotypePhenotypeMap
 from gpmap import utils
 
 # Local imports
-from epistasis.mapping import (mutations_to_sites, assert_epistasis)
+from epistasis.mapping import (encoding_to_sites, assert_epistasis)
 from .mapping import SimulatedEpistasisMap
 from epistasis.matrix import get_model_matrix
 from epistasis.utils import extract_mutations_from_genotypes
@@ -30,6 +30,7 @@ class BaseSimulation(GenotypePhenotypeMap):
         genotypes = np.array(
             utils.mutations_to_genotypes(mutations, wildtype=wildtype))
         phenotypes = np.ones(len(genotypes))
+
         # Initialize a genotype-phenotype map
         super(BaseSimulation, self).__init__(
             wildtype,
@@ -46,7 +47,7 @@ class BaseSimulation(GenotypePhenotypeMap):
         """Add an EpistasisMap to model.
         """
         # Build epistasis interactions as columns in X matrix.
-        sites = mutations_to_sites(self.order, self.mutations)
+        sites = encoding_to_sites(self.order, self.encoding_table)
 
         # Map those columns to epistastalis dataframe.
         self.epistasis = SimulatedEpistasisMap(gpm=self, sites=sites, values=0)

--- a/epistasis/utils.py
+++ b/epistasis/utils.py
@@ -12,7 +12,7 @@ from sklearn.metrics import mean_squared_error
 from collections import OrderedDict
 
 from gpmap.utils import genotypes_to_binary
-from .mapping import mutations_to_sites
+from .mapping import encoding_to_sites
 
 from epistasis.matrix import get_model_matrix
 
@@ -28,16 +28,19 @@ class SubclassException(Exception):
 # Useful methods
 # -------------------------------------------------------
 
-def genotypes_to_X(wildtype, genotypes,
-    order=1,
-    mutations=None,
-    model_type='global'):
+def genotypes_to_X(genotypes, gpm, order=1, model_type='global'):
     """Build an X matrix for a list of genotypes."""
-    # Binary representation
-    binary = genotypes_to_binary(wildtype, genotypes, mutations)
-
-    # Build list of sites from genotypes.
-    sites = mutations_to_sites(order, mutations)
+    # But a sites list.
+    sites = encoding_to_sites(
+        order,
+        gpm.encoding_table
+    )
+    # Get genotype column.
+    col = gpm.data.genotypes
+    # Get index of genotypes given.
+    loc = [col[col == g].index[0] for g in genotypes]
+    # Get binary values of genotypes using `loc`. Return as list
+    binary = gpm.data.loc[loc].binary.values.tolist()
 
     # X matrix
     X = get_model_matrix(binary, sites, model_type=model_type)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ atomicwrites>=1.2.1; python_version >= '2.7'
 attrs>=18.2.0
 cycler>=0.10.0
 emcee>=2.2.1
-gpmap>=0.4.5
+gpmap>=0.6.0
 kiwisolver>=1.0.1; python_version != '3.1.*'
 lmfit>=0.9.11
 matplotlib>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lmfit>=0.9.11
 matplotlib>=3.0.0
 more-itertools>=4.3.0
 numpy>=1.15.2
-pandas>=0.23.4
+pandas>=0.24.2
 pluggy>=0.7.1; python_version >= '2.7'
 py>=1.6.0; python_version >= '2.7'
 pyparsing>=2.2.2; python_version != '3.1.*'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ VERSION = None
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy>=1.15.2",
-    "pandas>=0.23.4",
+    "pandas>=0.24.2",
     "scikit-learn>=0.20.0",
     "scipy>=1.1.0",
     "emcee>=2.2.1",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ REQUIRED = [
     "emcee>=2.2.1",
     "lmfit>=0.9.11",
     "matplotlib>=3.0.0",
-    "gpmap>=0.4.5",
+    "gpmap>=0.6.0",
 ]
 
 # Extensions


### PR DESCRIPTION
This is a pretty significant change under the hood, so I'm bumping the version to 0.7.0. 

This uses the encoding table added GPMap (PR [#23](https://github.com/harmslab/gpmap/pull/23)) to construct epistatic coefficients (betas). Now, epistasis' `sites` array is clearly mapped to the betas and mutations index the represent in gpmap. This makes it easy to get the "label"s of epistatic coefficients. I've now added:
* `model.epistasis.get_label_mapper()` method: returns a dictionary mapping epistatic coeffs to their mutation
* `model.epistasis.labels` property: gets a list of coefficient labels